### PR TITLE
fix: autocomplete slug input add post on admin page

### DIFF
--- a/personal_blog/blog/admin.py
+++ b/personal_blog/blog/admin.py
@@ -4,6 +4,6 @@ class PostAdmin(admin.ModelAdmin):
     list_display = ('title', 'slug', 'status', 'created_on')
     list_filter = ('status',) 
     search_fields = ['title','content']
-    propopulated_fields = {'slug':('title',)}
+    prepopulated_fields = {'slug':('title',)}
 
 admin.site.register(Post, PostAdmin)


### PR DESCRIPTION
#8 - O bug do campo slug que não estava com autocomplete foi resolvido
<img width="683" height="158" alt="image" src="https://github.com/user-attachments/assets/060c9c1e-6881-446c-8660-2420f8f315d3" />
